### PR TITLE
Fix memory leaks

### DIFF
--- a/sshbook.c
+++ b/sshbook.c
@@ -237,6 +237,8 @@ int main() {
 			}
 		else if (c == 'q') {
 			disableRawMode();
+			free(addresses);
+			free(menu.items);
 			break;
 		} 
 		if (c == 'h') {
@@ -256,6 +258,8 @@ int main() {
 				char *sshAddress =strstr(connected, "/");
 				if (sshAddress) *sshAddress = '\0';
 				system(connected);
+				free(addresses);
+				free(menu.items);
 				break;
 
 			}	


### PR DESCRIPTION
**Valgrind output before change:**
==60126== HEAP SUMMARY:
==60126==     in use at exit: 262,188 bytes in 2 blocks
==60126==   total heap usage: 11 allocs, 9 frees, 273,966 bytes allocated
==60126== 
==60126== 44 bytes in 1 blocks are definitely lost in loss record 1 of 2
==60126==    at 0x483EB26: malloc (vg_replace_malloc.c:446)
==60126==    by 0x400913: getHomePath (sshbook.c:73)
==60126==    by 0x400DA9: main (sshbook.c:174)
==60126== 
==60126== 262,144 bytes in 1 blocks are definitely lost in loss record 2 of 2
==60126==    at 0x483EB26: malloc (vg_replace_malloc.c:446)
==60126==    by 0x400829: menuMake (sshbook.c:55)
==60126==    by 0x400DB9: main (sshbook.c:176)
==60126== 
==60126== LEAK SUMMARY:
==60126==    definitely lost: 262,188 bytes in 2 blocks
==60126==    indirectly lost: 0 bytes in 0 blocks
==60126==      possibly lost: 0 bytes in 0 blocks
==60126==    still reachable: 0 bytes in 0 blocks
==60126==         suppressed: 0 bytes in 0 blocks
==60126== 
==60126== For lists of detected and suppressed errors, rerun with: -s
==60126== ERROR SUMMARY: 2 errors from 2 contexts (suppressed: 0 from 0)

**Valgrind output after change:**
==61745== HEAP SUMMARY:
==61745==     in use at exit: 0 bytes in 0 blocks
==61745==   total heap usage: 6 allocs, 6 frees, 270,972 bytes allocated
==61745== 
==61745== All heap blocks were freed -- no leaks are possible
==61745== 
==61745== For lists of detected and suppressed errors, rerun with: -s
==61745== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)