### PR TITLE
Remove install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-cp ./sshbook /usr/local/bin/sshbook


### PR DESCRIPTION
The install section of the makefile does essentially the same thing as install.sh, so the latter doesn't really seem necessary.