### PR TITLE
Make function parameter lists explicit with void

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -4,7 +4,7 @@
 
 struct termios original_termios;
 
-int main() {
+int main(void) {
   char *addresses = getHomePath();
   Menu menu;
   menuMake(&menu);

--- a/src/paths.c
+++ b/src/paths.c
@@ -1,7 +1,7 @@
 #include "../include/paths.h"
 
 // expand home path, addresses file, etc.
-char *getHomePath() {
+char *getHomePath(void) {
   const char *home = getenv("HOME");
   if (!home) {
     struct passwd *pw = getpwuid(getuid());

--- a/src/term.c
+++ b/src/term.c
@@ -1,13 +1,13 @@
 #include "../include/term.h"
 
-void clearScreen() { write(STDOUT_FILENO, "\033[2J\033[H", 7); }
+void clearScreen(void) { write(STDOUT_FILENO, "\033[2J\033[H", 7); }
 
-void disableRawMode() {
+void disableRawMode(void) {
   tcsetattr(STDIN_FILENO, TCSAFLUSH, &original_termios);
   system("reset");
 }
 
-void enableRawMode() {
+void enableRawMode(void) {
   tcgetattr(STDIN_FILENO, &original_termios);
   atexit(disableRawMode);
   struct termios raw = original_termios;


### PR DESCRIPTION
GCC interprets functions declared as func() as having a nonspecific number and type of arguments. If they are instead declared as func(void), they take zero arguments and the compiler will warn/error if we pass something to them.