### PR TITLE
Improve handling of newline/carriage return when book is empty (revised)

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -92,6 +92,15 @@ int main() {
       break;
     case '\n':
     case '\r':
+      if (menu.count == 0) {
+        clearScreen();
+        printf("No entries have been defined.\n");
+      noEntriesLoop:
+        if (read(STDIN_FILENO, &choice, 1) != 1) {
+          goto noEntriesLoop;
+        }
+        break;
+      }
       disableRawMode();
       char connected[512] = "ssh ";
       strcat(connected, menu.items[selected]);

--- a/src/menu.c
+++ b/src/menu.c
@@ -79,7 +79,7 @@ void deleteItem(Menu *menu, const char *path, int *selected) {
     menu->items[i] = menu->items[i + 1];
   }
   menu->count--;
-  if (*selected >= menu->count) {
+  if (*selected >= menu->count && menu->count > 0) {
     *selected = menu->count - 1;
   }
   saveMenu(menu, path);


### PR DESCRIPTION
Added check for empty menu on newline/carriage return case in menu loop to prevent segmentation fault that was occurring in that path. Now shows message using same logic as help.

Edited logic in deleteItem to prevent selection from becoming negative when deleting all items in the list.
